### PR TITLE
Applying Atkinson Hyperlegible font override

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,15 @@
 
     <!-- Water.CSS stylsheets from JSDelivr -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.css">
+
+    <!-- Manual font override -->
+    <style>
+      @import url('https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:ital,wght@0,400;0,700;1,400;1,700&display=swap');
+
+      body {
+        font-family: "Atkinson Hyperlegible", sans-serif !important;
+      }
+    </style>
   </head>
 
   <body>


### PR DESCRIPTION
Replacing the default font from Water.css with Atkinson Hyperlegible -> improves accessibility for consumers with visual disabilities.